### PR TITLE
Map tweaks

### DIFF
--- a/map.html
+++ b/map.html
@@ -231,6 +231,15 @@
 							>
 								⌂
 							</button>
+							<button
+								class="zoom-btn"
+								onclick="togglePolygonVisibility()"
+								title="Toggle Polygons"
+							>
+								<svg fill="currentColor" width="18" height="18" viewBox="0 0 256 256" id="Flat" xmlns="http://www.w3.org/2000/svg">
+      								<path d="M227.8,52.2a28,28,0,0,0-39.6,0h0a28,28,0,0,0-5.88,8.65l-34.55-9.42A28,28,0,0,0,100.2,28.2h0a28,28,0,0,0-3.47,35.36L57.92,98.49A28,28,0,0,0,20.2,100.2h0a28,28,0,0,0,39.6,39.6l.18-.19,75.31,55.23A28,28,0,1,0,173,183.2l29.55-83.75A28,28,0,0,0,227.8,91.8,28,28,0,0,0,227.8,52.2ZM105.86,33.86h0a20,20,0,1,1,0,28.28A20,20,0,0,1,105.86,33.86Zm-80,100.28a20,20,0,0,1,0-28.28h0a20,20,0,1,1,0,28.28Zm148.28,88a20,20,0,0,1-28.28-28.28h0a20,20,0,0,1,28.28,28.28Zm-8.69-41.59a28,28,0,0,0-25.25,7.65h0l-.18.19L64.71,133.16a28.06,28.06,0,0,0-1.44-28.72l38.81-34.93a28,28,0,0,0,43.6-10.36l34.55,9.42A28,28,0,0,0,195,96.8Zm56.69-94.41a20,20,0,0,1-28.28-28.28h0a20,20,0,0,1,28.28,28.28Z"/>
+    							</svg>
+							</button>
 						</div>
 
 						<!-- Map Image -->
@@ -796,6 +805,13 @@
 				 and by DOMContentLoaded with setTimeout.
 				 So, we only need to call drawHighlights here.*/
 				drawHighlights();
+				mapCanvas.style.opacity = "0";
+				setTimeout(function (){
+					if (polygonsVisible){
+						mapCanvas.style.opacity = "1";
+						drawHighlights();
+					}
+				}, 400)
 			}
 
 			// Mouse drag functionality
@@ -991,7 +1007,7 @@
 				}
 			});
 
-			// Hide highlights when zooming (hovering)
+			/* Hide highlights when zooming (hovering)
 			if (mapImage && mapCanvas) {
 				mapImage.addEventListener("mouseenter", () => {
 					mapCanvas.style.opacity = "0";
@@ -1000,6 +1016,18 @@
 					mapCanvas.style.opacity = "1";
 					drawHighlights();
 				});
+			} */
+
+			let polygonsVisible = true;
+
+			function togglePolygonVisibility() {
+				polygonsVisible = !polygonsVisible;
+				if (mapCanvas) {
+					mapCanvas.style.opacity = polygonsVisible ? "1" : "0";
+					if(polygonsVisible){
+						drawHighlights();
+					}
+				}
 			}
 
 			// Redraw on ticket change


### PR DESCRIPTION
### Map Polygons:

**Fix:** Polygons now correctly align and scale during both zoom and pan operations. This was primarily a rendering synchronization issue between the map image's CSS transform and the canvas drawing, resolved by introducing a short delay to ensure the map image's transform settles before redrawing polygons.

**Behavior Change:** Polygons are now visible by default and stay visible when the map is moved (no longer hiding on hover). Their visibility is controlled solely by the new toggle button.


### "Toggle Polygons" Button:

Adds a new button to the map's zoom controls that toggles the visibility of the camping area polygons.